### PR TITLE
Fix a violation of the One Definition Rule

### DIFF
--- a/src/main/c/EcfInternal.h
+++ b/src/main/c/EcfInternal.h
@@ -127,8 +127,8 @@ void ecf_ExportParams_CloseFile (void);
 void ecf_ExportParams (float param[], int nparam, float chisq);
 
 // Vars for the export of params at each iteration
-int ecf_exportParams;
-char ecf_exportParams_path[256];
+extern int ecf_exportParams;
+extern char ecf_exportParams_path[256];
 
 void ecf_ExportParams_OpenFile (void);
 void ecf_ExportParams_CloseFile (void);

--- a/src/main/c/EcfUtil.c
+++ b/src/main/c/EcfUtil.c
@@ -1537,6 +1537,9 @@ int main(int ac, char **av)
 
 //***************************************** ExportParams ***********************************************/
 
+int ecf_exportParams;
+char ecf_exportParams_path[256];
+
 void ECF_ExportParams_start (char path[])
 {
 	ecf_exportParams = 1;


### PR DESCRIPTION
Move global variable definitions from header to source file, and keep declaration in header.

This came up while testing, on macOS, @facetorched's work-in-progress Python bindings for flimlib. It is not an error when building with `mvn`/`cmake` on macOS, presumably due to compiler flags, but we are trying a build based on Python's `setuptools` which is working on win/mac/linux except for this issue which causes a link error (duplicate symbol).