### PR TITLE
Consistent engine error handling

### DIFF
--- a/src/main/c/EcfSingle.c
+++ b/src/main/c/EcfSingle.c
@@ -1902,26 +1902,19 @@ int GCI_marquardt_fitting_engine(float xincr, float *trans, int ndata, int fit_s
 		fit_start = 0;
 	}
 
-	// All of the work is done by the ECF module
-	ret = GCI_marquardt_instr(xincr, trans, ndata, fit_start, fit_end,
-							  instr, ninstr, noise, sig,
-							  param, paramfree, nparam, restrain, fitfunc,
-							  fitted, residuals, covar, alpha, &local_chisq,
-							  chisq_delta, chisq_percent_float, erraxes);
-
 	// changed this for version 2, did a quick test with 2150ps_200ps_50cts_450cts.ics to see that the results are the same
 	// NB this is also in GCI_SPA_1D_marquardt_instr() and GCI_SPA_2D_marquardt_instr()
-	oldChisq = 3.0e38f;
-	while (local_chisq>chisq_target && (local_chisq<oldChisq) && tries<MAXREFITS)
-	{
+	local_chisq = 3.0e38f;
+	do {
 		oldChisq = local_chisq;
 		tries++;
+		// All of the work is done by the ECF module
 		ret += GCI_marquardt_instr(xincr, trans, ndata, fit_start, fit_end,
 							  instr, ninstr, noise, sig,
 							  param, paramfree, nparam, restrain, fitfunc,
 							  fitted, residuals, covar, alpha, &local_chisq,
 							  chisq_delta, chisq_percent_float, erraxes);
-	}
+	} while (local_chisq>chisq_target && (local_chisq<oldChisq) && tries<MAXREFITS);
 
 	if (chisq!=NULL) *chisq = local_chisq;
 

--- a/src/main/c/EcfSingle.c
+++ b/src/main/c/EcfSingle.c
@@ -1909,16 +1909,22 @@ int GCI_marquardt_fitting_engine(float xincr, float *trans, int ndata, int fit_s
 		oldChisq = local_chisq;
 		tries++;
 		// All of the work is done by the ECF module
-		ret += GCI_marquardt_instr(xincr, trans, ndata, fit_start, fit_end,
+		ret = GCI_marquardt_instr(xincr, trans, ndata, fit_start, fit_end,
 							  instr, ninstr, noise, sig,
 							  param, paramfree, nparam, restrain, fitfunc,
 							  fitted, residuals, covar, alpha, &local_chisq,
 							  chisq_delta, chisq_percent_float, erraxes);
+
+		if (ret < 0)
+			break;
 	} while (local_chisq>chisq_target && (local_chisq<oldChisq) && tries<MAXREFITS);
 
 	if (chisq!=NULL) *chisq = local_chisq;
 
 	if (ecf_exportParams) ecf_ExportParams_CloseFile ();
+
+	if (tries >= MAXREFITS && local_chisq > chisq_target) // maxrefits reached and target not reached
+		return -6;
 
 	return ret;		// summed number of iterations
 }

--- a/src/main/c/EcfSingle.c
+++ b/src/main/c/EcfSingle.c
@@ -446,7 +446,7 @@ int GCI_triple_integral_fitting_engine(float xincr, float y[], int fit_start, in
 		free (validFittedArray);
 	}
 
-	if (tries >= MAXREFITS)
+	if (tries >= MAXREFITS && local_chisq > chisq_target) // maxrefits reached and target not reached
 		return -5;
 	if (result < 0)
 		return result;


### PR DESCRIPTION
Error handling was not consistent between fitting engines. The fitting engines should return negative error codes if the tries reaches maxrefits and the chi squared target has still not been acheived. 

Furthermore, I fixed what I belive is a bug with `GCI_marquardt_fitting_engine` in that positive and negative error codes were summed and returned. This could result in a failed fit appearing like a success and vice-versa depending on the numbers summed. If the inner loop of the engine encounters an error, the engine should give up and raise that same error code. I would like to confirm with @ctrueden that this behaviour makes sense.