### PR TITLE
Fit many python

### DIFF
--- a/src/main/c/EcfMultiple.c
+++ b/src/main/c/EcfMultiple.c
@@ -277,8 +277,8 @@ int GCI_marquardt_fitting_engine_many(struct flim_params* flim) {
 
 int GCI_triple_integral_fitting_engine_many(struct flim_params* flim) {
 	int ninstr = flim->marquardt->instr == NULL ? 0 : flim->marquardt->instr->sizes[0];
-	// set the target to be NAN since this will cause the algorithm to iterate only once
-	float chisq_target_in = flim->triple_integral->chisq_target < 0 ? NAN : flim->triple_integral->chisq_target;
+	// set the target to be INFINITY since this will cause the algorithm to iterate only once
+	float chisq_target_in = flim->triple_integral->chisq_target < 0 ? INFINITY : flim->triple_integral->chisq_target;
 	
 	// allocate inputs and outputs. they may be NULL (no memory used) if not needed
 	float* temp_trans = allocate_temp_2d_row(flim->common->trans);

--- a/src/main/python/flimlib/cfunc.py
+++ b/src/main/python/flimlib/cfunc.py
@@ -776,7 +776,7 @@ def _prep_common_params(period, photon_count, fit_start, fit_end, fit_mask,
     common.residuals, residuals_out = _prep_optional_output(residuals, data_shape, (npixels, data_shape[-1]), flag=compute_residuals)
     common.chisq, chisq_out = _prep_optional_output(chisq, data_shape[0:-1], (npixels,), flag=compute_chisq)
     common.fit_mask, referenced_fit_mask = (None, None) if fit_mask is None else _as_strided_array(
-        fit_mask, (data_shape[0],), (npixels,), ctypes_type=ctypes.c_int8, numpy_type=np.int8)
+        fit_mask, data_shape[0:-1], (npixels,), ctypes_type=ctypes.c_int8, numpy_type=np.int8)
     referenced_objects = (referenced_trans, referenced_fit_mask) # stuff we want to prevent from getting garbage collected
     return common, fitted_out, residuals_out, chisq_out, data_shape, npixels, referenced_objects
 

--- a/src/main/python/flimlib/cfunc.py
+++ b/src/main/python/flimlib/cfunc.py
@@ -376,7 +376,7 @@ class FitFunc:
         if self.nparam_predicate is None or self.nparam_predicate(nparam_in):
             return self.c_func
         else:
-            raise TypeError("Incorrect size of param")
+            raise TypeError("Incorrect size of param: " + str(nparam_in))
 
 
 def _multiexp_predicate(n_param):
@@ -768,7 +768,7 @@ def _prep_common_params(period, photon_count, fit_start, fit_end, fit_mask,
     common.fit_start = fstart
     common.fit_end = fend
     data_shape = dshape if ndata_known else (*dshape[0:-1], fend) # triple_integral and phasor use fit_end as the size of the data
-    npixels = np.prod(data_shape[0:-1])
+    npixels = np.prod(data_shape[0:-1], dtype=int)
 
     common.xincr = period
     common.trans, referenced_trans = _as_strided_array(photon_count, ..., (npixels, dshape[-1])) # the shape of trans is wildcard
@@ -926,12 +926,14 @@ def GCI_marquardt_fitting_engine_many(  period, photon_count, param, fit_start=N
     referenced_paramfree
     referenced_objects
 
-    _copy_to_provided_output(fitted, fitted_out, data_shape)
-    _copy_to_provided_output(residuals, residuals_out, data_shape)
-    _copy_to_provided_output(chisq, chisq_out, data_shape[0:-1])
-    _copy_to_provided_output(covar, covar_out, (*data_shape[0:-1], nparam, nparam))
-    _copy_to_provided_output(alpha, alpha_out, (*data_shape[0:-1], nparam, nparam))
-    _copy_to_provided_output(erraxes, erraxes_out, (*data_shape[0:-1], nparam, nparam))
+    #print(data_shape)
+    param_out = _copy_to_provided_output(None, param_out, param_in.shape) # DO NOT copy to provided param since it is also an input
+    fitted_out = _copy_to_provided_output(fitted, fitted_out, data_shape)
+    residuals_out = _copy_to_provided_output(residuals, residuals_out, data_shape)
+    chisq_out = _copy_to_provided_output(chisq, chisq_out, data_shape[0:-1])
+    covar_out = _copy_to_provided_output(covar, covar_out, (*data_shape[0:-1], nparam, nparam))
+    alpha_out = _copy_to_provided_output(alpha, alpha_out, (*data_shape[0:-1], nparam, nparam))
+    erraxes_out = _copy_to_provided_output(erraxes, erraxes_out, (*data_shape[0:-1], nparam, nparam))
 
     return MarquardtManyResult( error_code, param_out, fitted_out, 
                             residuals_out, chisq_out, covar_out, alpha_out, erraxes_out)

--- a/src/main/python/flimlib/cfunc.py
+++ b/src/main/python/flimlib/cfunc.py
@@ -443,6 +443,7 @@ def GCI_marquardt_fitting_engine(  period, photon_count, param, fit_start=None, 
     -------
     MarquardtResult
         A namedtuple containing values in order: error_code, param, fitted, residuals, chisq, covar, alpha, erraxes
+        For each fit that fails, its corresponding outputs are filled with `NaN`
     """
     
     common_in, fitted_out, residuals_out, chisq_out, data_shape, npixels, referenced_objects = _prep_common_params(
@@ -582,6 +583,7 @@ def GCI_triple_integral_fitting_engine(period, photon_count, fit_start=None, fit
     -------
     TripleIntegralResult
         A namedtuple containing values in order: error_code, Z, A, tau, fitted, residuals, chisq
+        For each fit that fails, its corresponding outputs are filled with `NaN`
     """
     common_in, fitted_out, residuals_out, chisq_out, data_shape, npixels, referenced_objects = _prep_common_params(
         period, photon_count, fit_start, fit_end, fit_mask, fitted, residuals, chisq, compute_fitted, compute_residuals, compute_chisq, False)
@@ -708,6 +710,7 @@ def GCI_Phasor(period, photon_count, fit_start=None, fit_end=None,
     -------
     PhasorResult
         A namedtuple containing values in order: error_code, u, v, taup, taum, tau, fitted, residuals, chisq
+        For each fit that fails, its corresponding outputs are filled with `NaN`
     """
 
     common_in, fitted_out, residuals_out, chisq_out, data_shape, npixels, referenced_objects = _prep_common_params(

--- a/src/main/python/flimlib/cfunc.py
+++ b/src/main/python/flimlib/cfunc.py
@@ -831,16 +831,16 @@ def GCI_marquardt_fitting_engine_many(  period, photon_count, param, fit_start=N
     period : float
         The time between samples in `photon_count`
     photon_count : array_like
-        A 2D array containing the data to be fit. the first axis is spatial and the second is temporal
+        An N-dimensional array containing the data to be fit. The last axis is the time axis over which the data is fit. Any preceding axes will be preserved in the outputs.
     param : array_like
-        A 2D array of parameters. Provide parameter estimates, these are overridden with the fitted values. The first axis is spatial and the second must match the parameters of `fitfunc`
+        An N-dimensional array of parameters. Provide parameter estimates, these are overridden with the fitted values. The shape must match `photon_count` except the last axis, which must match the parameters of `fitfunc`
     fit_start : {None, int}, optional
         The index of the start of the fit. Some data before this start index is required if convolving with the prompt.
         If is None, the fit will begin at index 0 (default is None)
     fit_end : {None, int}, optional
-        The index of the end of the fit. If is None, the fit will cover the entire temporal axis of `photon_count`
+        The index of the end of the fit. If is None, the fit will cover the entire time axis of `photon_count`
     instr : {None, array_like}, optional
-        The instrument response (IRF) or prompt signal. If is None, no instrument response will be used
+        A 1D array containing the instrument response (IRF) or prompt signal. If is None, no instrument response will be used
         (default is None)
     noise_type : str, optional
         The noise type to use. Valid values are: 'NOISE_CONST', 'NOISE_GIVEN', 
@@ -857,17 +857,17 @@ def GCI_marquardt_fitting_engine_many(  period, photon_count, param, fit_start=N
     fitfunc : FitFunc, optional
         A FitFunc object that contains the fit function to be used in the fit. (default is GCI_multiexp_tau)
     fitted : {None, numpy.ndarray}, optional
-        A 2D array to be filled with the computed fitted plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed fitted plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     residuals : {None, numpy.ndarray}, optional
-        A 2D array to be filled with the computed residuals plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed residuals plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     chisq : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the computed raw chi squared value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed raw chi squared value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     covar : {None, numpy.ndarray}, optional
-        A 3D array to be filled with the computed covariance matrix for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed covariance matrix for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     alpha : {None, numpy.ndarray}, optional
-        A 3D array to be filled with the computed alpha matrix for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed alpha matrix for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     erraxes : {None, numpy.ndarray}, optional
-        A 3D array to be filled with the computed dimensions of the confidence ellipsoid of the chisq for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed dimensions of the confidence ellipsoid of the chisq for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     chisq_target : float, optional
         chisq_target A raw chi squared value to aim for. If this value is reached fitting will stop. If you want to aim for a reduced chisq (say 1.1 or 1.0) you must multiply by the degree of freedom. (default is 1.1)
     chisq_delta : float, optional
@@ -875,7 +875,7 @@ def GCI_marquardt_fitting_engine_many(  period, photon_count, param, fit_start=N
     chisq_percent : int, optional
         Defines the confidence interval when calculating the error axes (default is 95)
     fit_mask : {None, array_like}, optional
-        A 1D array of bool or 1s and 0s to select which pixels to fit. If is None, all pixels will be fit (default is None)
+        An N-dimensional array of bool or 1s and 0s to select which pixels to fit. If is None, all pixels will be fit (default is None)
     compute_fitted : bool, optional
         If True, the fitted plot for each fit is kept in memory and returned. Ignored if `fitted` is not None (default is True)
     compute_residuals : bool, optional
@@ -983,14 +983,14 @@ def GCI_triple_integral_fitting_engine_many(period, photon_count, fit_start=None
     period : float
         The time between samples in `photon_count`
     photon_count : array_like
-        A 2D array containing the data to be fit. the first axis is spatial and the second is temporal
+        An N-dimensional array containing the data to be fit. The last axis is the time axis over which the data is fit. Any preceding axes will be preserved in the outputs.
     fit_start : {None, int}, optional
         The index of the start of the fit. Some data before this start index is required if convolving with the prompt.
         If is None, the fit will begin at index 0 (default is None)
     fit_end : {None, int}, optional
-        The index of the end of the fit. If is None, the fit will cover the entire temporal axis of `photon_count`
+        The index of the end of the fit. If is None, the fit will cover the entire time axis of `photon_count`
     instr : {None, array_like}, optional
-        The instrument response (IRF) or prompt signal. If is None, no instrument response will be used
+        A 1D array containing the instrument response (IRF) or prompt signal. If is None, no instrument response will be used
         (default is None)
     noise_type : str, optional
         The noise type to use. Valid values are: 'NOISE_CONST', 'NOISE_GIVEN', 
@@ -1000,21 +1000,21 @@ def GCI_triple_integral_fitting_engine_many(period, photon_count, fit_start=None
         is 'NOISE_GIVEN', a float if `noise_type` is 'NOISE_CONST' and None otherwise 
         (default is None)
     Z : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the computed background value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed background value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     A : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the computed amplitude value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed amplitude value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     tau : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the computed lifetime value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed lifetime value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     fitted : {None, numpy.ndarray}, optional
-        A 2D array to be filled with the computed fitted plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed fitted plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     residuals : {None, numpy.ndarray}, optional
-        A 2D array to be filled with the computed residuals plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed residuals plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     chisq : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the computed raw chi squared value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed raw chi squared value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     chisq_target : float, optional
         chisq_target A raw chi squared value to aim for. If this value is reached fitting will stop. Retries will shorten the fit range (without changing fit_start). If you want to aim for a reduced chisq (say 1.1 or 1.0) you must multiply by the degree of freedom. A negative value will lead to only a single iteration (default is -1.0)
     fit_mask : {None, array_like}, optional
-        A 1D array of bool or 1s and 0s to select which pixels to fit. If is None, all pixels will be fit (default is None)
+        An N-dimensional array of bool or 1s and 0s to select which pixels to fit. If is None, all pixels will be fit (default is None)
     compute_fitted : bool, optional
         If True, the fitted plot for each fit is computed. If is False, residuals and chisq will also not be computed. Ignored if `fitted` is not None (default is True)
     compute_residuals : bool, optional
@@ -1115,32 +1115,32 @@ def GCI_Phasor_many(period, photon_count, fit_start=None, fit_end=None,
     period : float
         The time between samples in `photon_count`
     photon_count : array_like
-        A 2D array containing the data to be fit. the first axis is spatial and the second is temporal
+        An N-dimensional array containing the data to be fit. The last axis is the time axis over which the data is fit. Any preceding axes will be preserved in the outputs.
     fit_start : {None, int}, optional
         The index of the start of the fit. Some data before this start index is required if convolving with the prompt.
         If is None, the fit will begin at index 0 (default is None)
     fit_end : {None, int}, optional
-        The index of the end of the fit. If is None, the fit will cover the entire temporal axis of `photon_count`
+        The index of the end of the fit. If is None, the fit will cover the entire time axis of `photon_count`
     Z : {float, array_like}, optional
         The background to be subtracted from the data. If is a float, it will be constant for all pixels. (default is 0.0)
     u : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the computed 'horizontal' phasor coordinate. for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed 'horizontal' phasor coordinate. for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     v : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the computed 'vertical' phasor coordinate. for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed 'vertical' phasor coordinate. for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     taup : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the lifetime calculated from the phase change for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the lifetime calculated from the phase change for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     taum : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the lifetime calculated from the amplitude change for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the lifetime calculated from the amplitude change for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     tau : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the average of the other taus for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the average of the other taus for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     fitted : {None, numpy.ndarray}, optional
-        A 2D array to be filled with the computed fitted plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed fitted plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     residuals : {None, numpy.ndarray}, optional
-        A 2D array to be filled with the computed residuals plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed residuals plot for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     chisq : {None, numpy.ndarray}, optional
-        A 1D array to be filled with the computed reduced chi squared value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
+        An N-dimensional array to be filled with the computed reduced chi squared value for each fit. To avoid copying, use dtype=np.float32. If is None, a new array will be created (default is None)
     fit_mask : {None, array_like}, optional
-        A 1D array of bool or 1s and 0s to select which pixels to fit. If is None, all pixels will be fit (default is None)
+        An N-dimensional array of bool or 1s and 0s to select which pixels to fit. If is None, all pixels will be fit (default is None)
     compute_fitted : bool, optional
         If True, the fitted plot for each fit is computed. If is False, residuals and chisq will also not be computed. Ignored if `fitted` is not None (default is True)
     compute_residuals : bool, optional

--- a/src/test/python/test_flimlib.py
+++ b/src/test/python/test_flimlib.py
@@ -303,6 +303,11 @@ class TestMarquardtMany(unittest.TestCase):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)
         result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, fit_mask=[1,0], fitted=fitted_in)
         self.assertTrue(all(result.fitted[1] == 1))
+        # 3-dimensional photon_count
+        fitted_in = np.ones((2,2,samples), dtype=np.float32)
+        param_in = np.asarray([[[0,a_in+1,tau_in+1] for i in range(2)] for i in range(2)], dtype=np.float32)
+        result = flimlib.GCI_marquardt_fitting_engine_many(period, [photon_count2d[0:2], photon_count2d[0:2]], param_in, fit_mask=[[0,1],[1,0]], fitted=fitted_in)
+        self.assertTrue(all(result.fitted[0][0] == 1) and all(result.fitted[1][1] == 1))
     
     def test_paramfree(self):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)

--- a/src/test/python/test_flimlib.py
+++ b/src/test/python/test_flimlib.py
@@ -376,7 +376,7 @@ class Test3IntegralMany(unittest.TestCase):
         start = samples // 10
         end = samples // 10 * 9
         result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], fit_start=start, fit_end=end)
-        self.assertTrue(result.fitted.shape == (2, end))
+        self.assertEqual(result.fitted.shape, (2, end))
         self.assertTrue(np.all(np.diff(result.fitted) < 0)) # monotonic decrease
         self.assertAlmostEqual(result.fitted[0][0], result.A[0], 1)
 
@@ -475,6 +475,10 @@ class TestPhasorMany(unittest.TestCase):
         result = flimlib.GCI_Phasor_many(period, [[]])
         
 # TODO find fixes made to the many implementation that ought to go into single
+# TODO test all raises
+# TODO test 1d photon count
+# TODO test 3d+ photon count
+# TODO test jenu's bug
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/test/python/test_flimlib.py
+++ b/src/test/python/test_flimlib.py
@@ -1,7 +1,7 @@
 #unit tests
 import unittest
 import flimlib
-from flimlib.cfunc import GCI_marquardt_fitting_engine_many, TripleIntegralResult
+from flimlib.cfunc import GCI_marquardt_fitting_engine_many, GCI_triple_integral_fitting_engine, GCI_triple_integral_fitting_engine_many, TripleIntegralResult
 import numpy as np
 import math
 import time
@@ -512,6 +512,14 @@ class Test3IntegralMany(unittest.TestCase):
         flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_POISSON_FIT')
         # this should print a warning
         flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_POISSON_FIT',sig=2)
+
+    def test_failed_fit(self):
+        result = flimlib.GCI_triple_integral_fitting_engine_many(period, np.flip(photon_count2d[0:2]))
+        self.assertTrue(np.all(np.isnan(result.Z)))
+        self.assertTrue(np.all(np.isnan(result.A)))
+        self.assertTrue(np.all(np.isnan(result.tau)))
+        self.assertTrue(np.all(np.isnan(result.fitted)))
+        self.assertTrue(np.all(np.isnan(result.residuals)))
 
 class TestPhasorMany(unittest.TestCase):
     def test_output_margin(self):

--- a/src/test/python/test_flimlib.py
+++ b/src/test/python/test_flimlib.py
@@ -1,7 +1,6 @@
 #unit tests
 import unittest
 import flimlib
-from flimlib.cfunc import GCI_marquardt_fitting_engine_many, GCI_triple_integral_fitting_engine, GCI_triple_integral_fitting_engine_many, TripleIntegralResult
 import numpy as np
 import math
 import time
@@ -46,15 +45,13 @@ class Test3Integral(unittest.TestCase):
         self.assertAlmostEqual(result.A, a_in * error_factor, 1)
         self.assertAlmostEqual(result.tau, tau_in, 1)
         self.assertAlmostEqual(result.Z, 0.0, 1)
-        self.assertTrue(result.error_code>0)
+        #self.assertTrue(result.error_code>0) error code no longer says anything about the fit
         self.assertAlmostEqual(result.fitted[0], a_in * error_factor, 1)
 
 
     def test_photon_count(self):
         flimlib.GCI_triple_integral_fitting_engine(period, photon_count64) #passing float 64 should be fine
-        with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d) #passing 2d array will fail
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             flimlib.GCI_triple_integral_fitting_engine(period, 5.7) #must be 1d array
         flimlib.GCI_triple_integral_fitting_engine(period, [1,2])
 
@@ -84,7 +81,7 @@ class Test3Integral(unittest.TestCase):
     def test_noise_const(self):
         flimlib.GCI_triple_integral_fitting_engine(period, photon_count32, noise_type='NOISE_CONST',sig=2)
         flimlib.GCI_triple_integral_fitting_engine(period, photon_count32, noise_type='NOISE_CONST',sig=[5])
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             flimlib.GCI_triple_integral_fitting_engine(period, photon_count32, noise_type='NOISE_CONST',sig=[1,2,3,4,5])
         with self.assertRaises(ValueError):
             flimlib.GCI_triple_integral_fitting_engine(period, photon_count32, noise_type='NOISE_CONST',sig='foo')
@@ -120,8 +117,8 @@ class Test3Integral(unittest.TestCase):
         flimlib.GCI_triple_integral_fitting_engine(period, photon_count32, noise_type='NOISE_POISSON_FIT',sig=2)
     
     def test_chisq_target(self):
-        result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count32, chisq_target=0.0) #impossible target causes it to run more than once and give up
-        self.assertTrue(result.error_code>1)
+        result = flimlib.GCI_triple_integral_fitting_engine(period, np.flip(photon_count32), chisq_target=0.0) #impossible target causes it to run more than once and give up
+        #self.assertTrue(result.error_code>1)
 
 class TestPhasor(unittest.TestCase):
     def test_output_margin(self):
@@ -209,26 +206,21 @@ class TestMarquardt(unittest.TestCase):
         # any odd number of parameters greater or equal to 3 should work!
         param_in = np.asarray([0, a_in+1,tau_in+1, 1, 1], dtype=np.float32) # pass 5 parameters
         flimlib.GCI_marquardt_fitting_engine(period, photon_count_linear, param_in)
-
-    def test_param_modified(self):
-        param_in = np.asarray([0,a_in+1,tau_in+1], dtype=np.float32) # slight offset to detect if the fitting works!
-        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count32, param_in)
-        self.assertEqual(param_in.data, result.param.data) # make sure that the values are modified in-place. We want to save memory!
     
 class TestMarquardtMany(unittest.TestCase):
     def test_output_margin(self):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(samples*samples)], dtype=np.float32) # slight offset to detect if the fitting works!
         start = time.time_ns()
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d, param_in)
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d, param_in)
         end = time.time_ns()
-        print("GCI_marquardt_fitting_engine_many ran on ", samples*samples, "pixels, took", (end-start)/1000000, "milliseconds")
+        print("GCI_marquardt_fitting_engine ran on ", samples*samples, "pixels, took", (end-start)/1000000, "milliseconds")
         for i in range(samples*samples):
             self.assertAlmostEqual(result.param[i][1], a_in1d[i], 1)
             self.assertAlmostEqual(result.param[i][2], tau_in1d[i], 1)
 
     def test_integer_input(self):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.int16)
-        flimlib.GCI_marquardt_fitting_engine_many(period, np.asarray(photon_count2d[0:2],dtype=int), param_in)
+        flimlib.GCI_marquardt_fitting_engine(period, np.asarray(photon_count2d[0:2],dtype=int), param_in)
     
     def test_outputs_modified(self):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)
@@ -238,7 +230,7 @@ class TestMarquardtMany(unittest.TestCase):
         covar_in = np.empty((2,3,3), dtype=np.float32)
         alpha_in = np.empty((2,3,3), dtype=np.float32)
         erraxes_in = np.empty((2,3,3), dtype=np.float32)
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, 
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, 
             fitted=fitted_in, residuals=residuals_in, chisq=chisq_in, covar=covar_in, alpha=alpha_in, erraxes=erraxes_in)
         self.assertTrue(np.all(result.param != param_in)) # param must NOT be equal
         self.assertTrue(np.all(result.fitted == fitted_in))
@@ -255,7 +247,7 @@ class TestMarquardtMany(unittest.TestCase):
         covar_in = np.empty((2,3,3), dtype=np.float64)
         alpha_in = np.empty((2,3,3), dtype=np.float64)
         erraxes_in = np.empty((2,3,3), dtype=np.float64)
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, 
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, 
             fitted=fitted_in, residuals=residuals_in, chisq=chisq_in, covar=covar_in, alpha=alpha_in, erraxes=erraxes_in)
         self.assertTrue(np.all(result.param != param_in)) # param must NOT be equal
         self.assertTrue(np.all(result.fitted == fitted_in))
@@ -269,64 +261,64 @@ class TestMarquardtMany(unittest.TestCase):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)
         with self.assertRaises(TypeError):
             fitted_in = np.empty((2,samples), dtype=int) # not compatible
-            result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, fitted=fitted_in)
+            result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, fitted=fitted_in)
         with self.assertRaises(ValueError):
             fitted_in = np.empty((2,samples+3), dtype=np.float32) # too large
-            result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, fitted=fitted_in)
+            result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, fitted=fitted_in)
         with self.assertRaises(ValueError):
             fitted_in = np.empty((2,samples-3), dtype=np.float32) # too small
-            result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, fitted=fitted_in)
+            result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, fitted=fitted_in)
 
     def test_fit_start_end(self):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)
         start = samples // 10
         end = samples // 10 * 9
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, fit_start=start, fit_end=end)
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, fit_start=start, fit_end=end)
         self.assertTrue(result.fitted.shape == (2, samples))
         self.assertTrue(np.all(np.diff(result.fitted) < 0)) # monotonic decrease
         self.assertAlmostEqual(result.fitted[0][0], result.param[0][1], 1)
 
     def test_compute_flags(self):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, 
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, 
             compute_fitted=False, compute_residuals=False, compute_chisq=False, compute_covar=False, compute_alpha=False, compute_erraxes=False)
         self.assertTrue(result.fitted == result.residuals == result.chisq == result.covar == result.alpha == result.erraxes == None)
 
     def test_strided(self):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)
         fitted_strided = np.flip(np.empty((2,samples), dtype=np.float32)[:,0:-1:2])
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, trans_strided, param_in, fitted=fitted_strided)
+        result = flimlib.GCI_marquardt_fitting_engine(period, trans_strided, param_in, fitted=fitted_strided)
         self.assertEqual(result.fitted.strides, (samples * -4, -8))
 
     def test_fitmask(self):
         fitted_in = np.ones((2,samples), dtype=np.float32)
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, fit_mask=[1,0], fitted=fitted_in)
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, fit_mask=[1,0], fitted=fitted_in)
         self.assertTrue(all(result.fitted[1] == 1))
         # 3-dimensional photon_count
         fitted_in = np.ones((2,2,samples), dtype=np.float32)
         param_in = np.asarray([[[0,a_in+1,tau_in+1] for i in range(2)] for i in range(2)], dtype=np.float32)
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, [photon_count2d[0:2], photon_count2d[0:2]], param_in, fit_mask=[[0,1],[1,0]], fitted=fitted_in)
+        result = flimlib.GCI_marquardt_fitting_engine(period, [photon_count2d[0:2], photon_count2d[0:2]], param_in, fit_mask=[[0,1],[1,0]], fitted=fitted_in)
         self.assertTrue(all(result.fitted[0][0] == 1) and all(result.fitted[1][1] == 1))
     
     def test_paramfree(self):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, paramfree=[1,0,1])
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, paramfree=[1,0,1])
         self.assertEqual(result.param[0][1], a_in+1)
 
     def test_size_zero_input(self):
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, [[]], [[]])
+        result = flimlib.GCI_marquardt_fitting_engine(period, [[]], [[]])
         
     def test_chisq_target(self):
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)
         with self.assertRaises(TypeError):
-            result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, chisq_target="foo")
+            result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, chisq_target="foo")
         
     def test_different_shapes(self):
         param_in = np.asarray([[[0,a_in+1,tau_in+1] for i in range(2)] for i in range(2)], dtype=np.float32)
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, [photon_count2d[0:2], photon_count2d[0:2]], param_in)
+        result = flimlib.GCI_marquardt_fitting_engine(period, [photon_count2d[0:2], photon_count2d[0:2]], param_in)
         self.assertEqual(result.fitted.shape, (2, 2, samples))
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count32, [0,a_in+1,tau_in+1])
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count32, [0,a_in+1,tau_in+1])
         self.assertEqual(result.fitted.shape, (samples,))
 
     def test_restraintype(self):
@@ -336,20 +328,20 @@ class TestMarquardtMany(unittest.TestCase):
             flimlib.GCI_set_restrain_limits([[0,0],[0,0]],[0,0],[0,0])
         param_in = np.asarray([[0,a_in+1,tau_in+1] for i in range(2)], dtype=np.float32)
         flimlib.GCI_set_restrain_limits([0,1,0],[0,0,0],[0,a_in-1,0])
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count2d[0:2], param_in, restrain_type='ECF_RESTRAIN_USER')
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count2d[0:2], param_in, restrain_type='ECF_RESTRAIN_USER')
         self.assertTrue(all(result.param[1] <= a_in-1))
     
     def test_multiexp_lambda(self):
         lambda_in = 1/tau_in # lambda is the decay rate!
         param_in = np.asarray([0,a_in+1,lambda_in+1], dtype=np.float32)
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count32, param_in, fitfunc=flimlib.GCI_multiexp_lambda)
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count32, param_in, fitfunc=flimlib.GCI_multiexp_lambda)
         self.assertAlmostEqual(a_in, result.param[1], 1)
         self.assertAlmostEqual(lambda_in, result.param[2],1)
     
     def test_user_defined_fitfunc(self):
         param_in = np.asarray([0,a_in+1,tau_in+1], dtype=np.float32)
         fitfunc_in = flimlib.FitFunc(dummy_exp_tau, nparam_predicate=dummy_exp_tau_predicate)
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count32, param_in, fitfunc=fitfunc_in)
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count32, param_in, fitfunc=fitfunc_in)
         self.assertAlmostEqual(0.0,result.param[0],1)
         self.assertAlmostEqual(a_in,result.param[1],1)
         self.assertAlmostEqual(tau_in,result.param[2],1)
@@ -357,7 +349,7 @@ class TestMarquardtMany(unittest.TestCase):
         # linear fit! (did not work with the first param being nonzero)
         param_in = np.asarray([0, linear_const+1], dtype=np.float32)
         fitfunc_in = flimlib.FitFunc(dummy_linear, nparam_predicate=dummy_linear_predicate)
-        result = flimlib.GCI_marquardt_fitting_engine_many(period, photon_count_linear, param_in, fitfunc=fitfunc_in, noise_type='NOISE_CONST',sig=1.0)
+        result = flimlib.GCI_marquardt_fitting_engine(period, photon_count_linear, param_in, fitfunc=fitfunc_in, noise_type='NOISE_CONST',sig=1.0)
         self.assertAlmostEqual(0.0,result.param[0],1)
         self.assertAlmostEqual(linear_const,result.param[1],1)
 
@@ -373,9 +365,9 @@ class TestMarquardtMany(unittest.TestCase):
 class Test3IntegralMany(unittest.TestCase):
     def test_output_margin(self):
         start = time.time_ns()
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d)
+        result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d)
         end = time.time_ns()
-        print("GCI_triple_integral_fitting_engine_many ran on ", samples*samples, "pixels, took", (end-start)/1000000, "milliseconds")
+        print("GCI_triple_integral_fitting_engine ran on ", samples*samples, "pixels, took", (end-start)/1000000, "milliseconds")
         for i in range(samples*samples):
             self.assertAlmostEqual(result.tau[i], tau_in1d[i], 1)
             self.assertAlmostEqual(result.A[i], a_in1d[i] * error_factor1d[i], 1)
@@ -387,7 +379,7 @@ class Test3IntegralMany(unittest.TestCase):
         Z_in = np.empty((2,), dtype=np.float32)
         A_in = np.empty((2,), dtype=np.float32)
         tau_in = np.empty((2,), dtype=np.float32)
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2],
+        result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2],
             fitted=fitted_in, residuals=residuals_in, chisq=chisq_in, Z=Z_in, A=A_in, tau=tau_in)
         self.assertTrue(np.all(result.fitted == fitted_in))
         self.assertTrue(np.all(result.residuals == residuals_in))
@@ -402,7 +394,7 @@ class Test3IntegralMany(unittest.TestCase):
         Z_in = np.empty((2,), dtype=np.float64)
         A_in = np.empty((2,), dtype=np.float64)
         tau_in = np.empty((2,), dtype=np.float64)
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2],
+        result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2],
             fitted=fitted_in, residuals=residuals_in, chisq=chisq_in, Z=Z_in, A=A_in, tau=tau_in)
         self.assertTrue(np.all(result.fitted == fitted_in))
         self.assertTrue(np.all(result.residuals == residuals_in))
@@ -413,108 +405,108 @@ class Test3IntegralMany(unittest.TestCase):
 
     def test_wrong_output_type(self):
         fitted_in = np.empty((2,samples), dtype=np.float64) # float64 is compatible
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], fitted=fitted_in)
+        result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], fitted=fitted_in)
         self.assertTrue(np.all(result.fitted == fitted_in))
         with self.assertRaises(TypeError):
             fitted_in = np.empty((2,samples), dtype=int) # not compatible
-            result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], fitted=fitted_in)
+            result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], fitted=fitted_in)
         with self.assertRaises(ValueError):
             fitted_in = np.empty((2,samples+3), dtype=np.float32) # too large
-            result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], fitted=fitted_in)
+            result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], fitted=fitted_in)
         with self.assertRaises(ValueError):
             fitted_in = np.empty((2,samples-3), dtype=np.float32) # too small
-            result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], fitted=fitted_in)
+            result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], fitted=fitted_in)
     
     def test_fit_start_end(self):
         start = samples // 10
         end = samples // 10 * 9
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], fit_start=start, fit_end=end)
+        result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], fit_start=start, fit_end=end)
         self.assertEqual(result.fitted.shape, (2, end))
         self.assertTrue(np.all(np.diff(result.fitted) < 0)) # monotonic decrease
         self.assertAlmostEqual(result.fitted[0][0], result.A[0], 1)
 
     def test_compute_flags(self):
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2],
+        result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2],
             compute_fitted=False, compute_residuals=False, compute_chisq=False)
         self.assertTrue(result.fitted == result.residuals == result.chisq)
 
     def test_strided(self):
         fitted_strided = np.flip(np.empty((2,samples), dtype=np.float32)[:,0:-1:2])
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period * 2, trans_strided, fitted=fitted_strided)
+        result = flimlib.GCI_triple_integral_fitting_engine(period * 2, trans_strided, fitted=fitted_strided)
         self.assertEqual(result.fitted.strides, (samples * -4, -8))
 
     def test_size_zero_input(self):
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period, [[]])
+        result = flimlib.GCI_triple_integral_fitting_engine(period, [[]])
 
     def test_different_shapes(self):
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period, [photon_count2d[0:2], photon_count2d[0:2]])
+        result = flimlib.GCI_triple_integral_fitting_engine(period, [photon_count2d[0:2], photon_count2d[0:2]])
         self.assertEqual(result.fitted.shape, (2, 2, samples))
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count32)
+        result = flimlib.GCI_triple_integral_fitting_engine(period, photon_count32)
         self.assertEqual(result.fitted.shape, (samples,))
 
     def test_instr(self):
-        flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], instr=[1,2,3,4,5])
-        flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], instr=["42"])
-        flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], instr=list(range(300))) # no errors??? ask mark/jenu. ok we should actually just check that it's the right length
+        flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], instr=[1,2,3,4,5])
+        flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], instr=["42"])
+        flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], instr=list(range(300))) # no errors??? ask mark/jenu. ok we should actually just check that it's the right length
         with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], instr=5)
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], instr=5)
         with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], instr="foo")
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], instr="foo")
         with self.assertRaises(TypeError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], instr={"foo": "bar"})
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], instr={"foo": "bar"})
 
     def test_noise_type_input(self):
         with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='foo')
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='foo')
         with self.assertRaises(TypeError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type={"foo": "bar"})
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type={"foo": "bar"})
 
     def test_unused_noise_types(self):
         with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_GAUSSIAN_FIT')
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_GAUSSIAN_FIT')
         with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_MLE')
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_MLE')
 
     def test_noise_const(self):
-        flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_CONST',sig=2)
-        flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_CONST',sig=[5])
+        flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_CONST',sig=2)
+        flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_CONST',sig=[5])
         with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_CONST',sig=[1,2,3,4,5])
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_CONST',sig=[1,2,3,4,5])
         with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_CONST',sig='foo')
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_CONST',sig='foo')
     
     def test_noise_given(self):
-        flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig=list(range(samples)))
+        flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig=list(range(samples)))
         with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig=2)
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig=2)
         with self.assertRaises(TypeError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig={"foo": "bar"})
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig={"foo": "bar"})
         with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig='foo')
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig='foo')
         with self.assertRaises(ValueError):
-            flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig=[1,2,3,4,5])
+            flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig=[1,2,3,4,5])
         
     def test_noise_const_and_given(self):
         #the result should be the same if noise given is constant
-        result_const = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_CONST',sig=1.0)
-        result_noise_given = flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig=np.ones(samples))
+        result_const = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_CONST',sig=1.0)
+        result_noise_given = flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_GIVEN',sig=np.ones(samples))
         self.assertTrue(all(result_const.chisq == result_noise_given.chisq))
         self.assertTrue(all(result_const.A == result_noise_given.A))
         self.assertTrue(all(result_const.Z == result_noise_given.Z))
         self.assertTrue(all(result_const.tau == result_noise_given.tau))
 
     def test_noise_poisson_data(self):
-        flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_POISSON_DATA')
+        flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_POISSON_DATA')
         # this should print a warning
-        flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_POISSON_DATA',sig=2)
+        flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_POISSON_DATA',sig=2)
 
     def test_noise_poisson_fit(self):
-        flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_POISSON_FIT')
+        flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_POISSON_FIT')
         # this should print a warning
-        flimlib.GCI_triple_integral_fitting_engine_many(period, photon_count2d[0:2], noise_type='NOISE_POISSON_FIT',sig=2)
+        flimlib.GCI_triple_integral_fitting_engine(period, photon_count2d[0:2], noise_type='NOISE_POISSON_FIT',sig=2)
 
     def test_failed_fit(self):
-        result = flimlib.GCI_triple_integral_fitting_engine_many(period, np.flip(photon_count2d[0:2]))
+        result = flimlib.GCI_triple_integral_fitting_engine(period, np.flip(photon_count2d[0:2]))
         self.assertTrue(np.all(np.isnan(result.Z)))
         self.assertTrue(np.all(np.isnan(result.A)))
         self.assertTrue(np.all(np.isnan(result.tau)))
@@ -524,9 +516,9 @@ class Test3IntegralMany(unittest.TestCase):
 class TestPhasorMany(unittest.TestCase):
     def test_output_margin(self):
         start = time.time_ns()
-        result = flimlib.GCI_Phasor_many(period, photon_count2d)
+        result = flimlib.GCI_Phasor(period, photon_count2d)
         end = time.time_ns()
-        print("GCI_Phasor_many ran on ", samples*samples, "pixels, took", (end-start)/1000000, "milliseconds")
+        print("GCI_Phasor ran on ", samples*samples, "pixels, took", (end-start)/1000000, "milliseconds")
         self.assertFalse(any(result.chisq > 1)) # for this I assume that the reduced chi squared is a reliable metric
     
     def test_outputs_modified(self):
@@ -538,7 +530,7 @@ class TestPhasorMany(unittest.TestCase):
         fitted_in = np.empty((2,samples), dtype=np.float32)
         residuals_in = np.empty((2,samples), dtype=np.float32)
         chisq_in = np.empty((2,), dtype=np.float32)
-        result = flimlib.GCI_Phasor_many(period, photon_count2d[0:2],
+        result = flimlib.GCI_Phasor(period, photon_count2d[0:2],
             fitted=fitted_in, residuals=residuals_in, chisq=chisq_in, u=u_in, v=v_in, taup=taup_in, taum=taum_in, tau=tau_in)
         self.assertTrue(np.all(result.v == v_in))
         self.assertTrue(np.all(result.u == u_in))
@@ -557,7 +549,7 @@ class TestPhasorMany(unittest.TestCase):
         fitted_in = np.empty((2,samples), dtype=np.float64)
         residuals_in = np.empty((2,samples), dtype=np.float64)
         chisq_in = np.empty((2,), dtype=np.float64)
-        result = flimlib.GCI_Phasor_many(period, photon_count2d[0:2],
+        result = flimlib.GCI_Phasor(period, photon_count2d[0:2],
             fitted=fitted_in, residuals=residuals_in, chisq=chisq_in, u=u_in, v=v_in, taup=taup_in, taum=taum_in, tau=tau_in)
         self.assertTrue(np.all(result.v == v_in))
         self.assertTrue(np.all(result.u == u_in))
@@ -570,48 +562,48 @@ class TestPhasorMany(unittest.TestCase):
 
     def test_wrong_output_type(self):
         fitted_in = np.empty((2,samples), dtype=np.float64) # float64 is compatible
-        result = flimlib.GCI_Phasor_many(period, photon_count2d[0:2], fitted=fitted_in)
+        result = flimlib.GCI_Phasor(period, photon_count2d[0:2], fitted=fitted_in)
         self.assertTrue(np.all(result.fitted == fitted_in))
         with self.assertRaises(TypeError):
             fitted_in = np.empty((2,samples), dtype=int) # not compatible
-            result = flimlib.GCI_Phasor_many(period, photon_count2d[0:2], fitted=fitted_in)
+            result = flimlib.GCI_Phasor(period, photon_count2d[0:2], fitted=fitted_in)
         with self.assertRaises(ValueError):
             fitted_in = np.empty((2,samples+3), dtype=np.float32) # too large
-            result = flimlib.GCI_Phasor_many(period, photon_count2d[0:2], fitted=fitted_in)
+            result = flimlib.GCI_Phasor(period, photon_count2d[0:2], fitted=fitted_in)
         with self.assertRaises(ValueError):
             fitted_in = np.empty((2,samples-3), dtype=np.float32) # too small
-            result = flimlib.GCI_Phasor_many(period, photon_count2d[0:2], fitted=fitted_in)
+            result = flimlib.GCI_Phasor(period, photon_count2d[0:2], fitted=fitted_in)
 
     def test_fit_start_end(self):
         start = samples // 10
         end = samples // 10 * 9
-        result = flimlib.GCI_Phasor_many(period, photon_count2d[0:2], fit_start=start, fit_end=end)
+        result = flimlib.GCI_Phasor(period, photon_count2d[0:2], fit_start=start, fit_end=end)
         self.assertTrue(np.all(np.diff(result.fitted[:,start:end]) < 0)) # monotonic decrease
         self.assertTrue(result.fitted.shape == (2, end))
 
     def test_compute_flags(self):
-        result = flimlib.GCI_Phasor_many(period, photon_count2d[0:2],
+        result = flimlib.GCI_Phasor(period, photon_count2d[0:2],
             compute_fitted=False, compute_residuals=False, compute_chisq=False)
         self.assertTrue(result.fitted == result.residuals == result.chisq)
 
     def test_strided(self):
         fitted_strided = np.flip(np.empty((2,samples), dtype=np.float32)[:,0:-1:2])
-        result = flimlib.GCI_Phasor_many(period, trans_strided, fitted=fitted_strided)
+        result = flimlib.GCI_Phasor(period, trans_strided, fitted=fitted_strided)
         self.assertEqual(result.fitted.strides, (samples * -4, -8))
 
     def test_size_zero_input(self):
-        result = flimlib.GCI_Phasor_many(period, [[]])
-        result = flimlib.GCI_Phasor_many(period, [])
+        result = flimlib.GCI_Phasor(period, [[]])
+        result = flimlib.GCI_Phasor(period, [])
     
     def test_different_shapes(self):
-        result = flimlib.GCI_Phasor_many(period, [photon_count2d[0:2], photon_count2d[0:2]])
+        result = flimlib.GCI_Phasor(period, [photon_count2d[0:2], photon_count2d[0:2]])
         self.assertEqual(result.fitted.shape, (2, 2, samples))
-        result = flimlib.GCI_Phasor_many(period, photon_count32)
+        result = flimlib.GCI_Phasor(period, photon_count32)
         self.assertEqual(result.fitted.shape, (samples,))
         
 # TODO find fixes made to the many implementation that ought to go into single
-# TODO test jenu's bug
-# TODO set outputs to nan on failed fit
+# TODO replace non-many functions with many implementation
+# TODO pass error codes through on single fits?
 
 if __name__ == '__main__':
-    unittest.main()
+    unittest.main() 

--- a/src/test/python/test_flimlib.py
+++ b/src/test/python/test_flimlib.py
@@ -513,6 +513,14 @@ class Test3IntegralMany(unittest.TestCase):
         self.assertTrue(np.all(np.isnan(result.fitted)))
         self.assertTrue(np.all(np.isnan(result.residuals)))
 
+    def test_fit_fail(self):
+        result = flimlib.GCI_triple_integral_fitting_engine_many(period, np.flip(photon_count2d[0:2]))
+        self.assertTrue(np.all(np.isnan(result.Z)))
+        self.assertTrue(np.all(np.isnan(result.A)))
+        self.assertTrue(np.all(np.isnan(result.tau)))
+        self.assertTrue(np.all(np.isnan(result.fitted)))
+        self.assertTrue(np.all(np.isnan(result.residuals)))
+
 class TestPhasorMany(unittest.TestCase):
     def test_output_margin(self):
         start = time.time_ns()


### PR DESCRIPTION
"many" functions  are now named without the `*_many` suffix since they support n-dimensional input/output. Fit errors are now reported by filling outputs with `NaN` and outputs utilize the python `dataclass` instead of `NamedTuple`