### PR TITLE
Bugfixes for failed fits

### DIFF
--- a/src/main/c/EcfMultiple.c
+++ b/src/main/c/EcfMultiple.c
@@ -270,6 +270,9 @@ int GCI_marquardt_fitting_engine_many(struct flim_params* flim) {
 				write_2d_row_nan(flim->marquardt->param, i);
 				write_2d_row_nan(flim->common->fitted, i);
 				write_2d_row_nan(flim->common->residuals, i);
+				if (unstrided_chisq != NULL){
+					*unstrided_chisq = NAN;
+				}
 				write_matrix_nan(flim->marquardt->covar, i);
 				write_matrix_nan(flim->marquardt->alpha, i);
 				write_matrix_nan(flim->marquardt->erraxes, i);
@@ -340,6 +343,9 @@ int GCI_triple_integral_fitting_engine_many(struct flim_params* flim) {
 				*array1d_float_ptr(flim->triple_integral->tau, i) = NAN;
 				write_2d_row_nan(flim->common->fitted, i);
 				write_2d_row_nan(flim->common->residuals, i);
+				if (unstrided_chisq != NULL){
+					*unstrided_chisq = NAN;
+				}
 			}
 			else{
 				write_2d_row_output(unstrided_fitted, flim->common->fitted, i);
@@ -385,6 +391,9 @@ int GCI_Phasor_many(struct flim_params* flim) {
 				*array1d_float_ptr(flim->phasor->tau, i) = NAN;
 				write_2d_row_nan(flim->common->fitted, i);
 				write_2d_row_nan(flim->common->residuals, i);
+				if (unstrided_chisq != NULL){
+					*unstrided_chisq = NAN;
+				}
 			}
 			else{
 				write_2d_row_output(unstrided_fitted, flim->common->fitted, i);

--- a/src/test/python/test_flimlib.py
+++ b/src/test/python/test_flimlib.py
@@ -473,6 +473,7 @@ class Test3Integral(unittest.TestCase):
         self.assertTrue(np.all(np.isnan(result.tau)))
         self.assertTrue(np.all(np.isnan(result.fitted)))
         self.assertTrue(np.all(np.isnan(result.residuals)))
+        self.assertTrue(np.all(np.isnan(result.chisq)))
 
 
 class TestPhasor(unittest.TestCase):
@@ -981,8 +982,9 @@ class TestMarquardt(unittest.TestCase):
             photon_count2d[0:2],
             param_in,
             restrain_type="ECF_RESTRAIN_USER",
+            chisq_target=np.Infinity,
         )
-        self.assertTrue(all(result.param[1] <= a_in - 1))
+        self.assertTrue(all(result.param[:,1] <= a_in - 1))
 
     def test_multiexp_lambda(self):
         lambda_in = 1 / tau_in  # lambda is the decay rate!


### PR DESCRIPTION
I forgot to set `chisq` to NAN on failed fits. Added a test for this and also noticed that the test for restrain was failing but for a good reason (the fit was failing since it was unable to acheive `chisq_target`). Restraining `param` away from the target value will clearly result in a larger chisq. Therefore I set `chisq_target` to infinity so that the fit would not fail and the behavior of the restrain could be verified.