### PR TITLE
correctly handle optional computes in single pixel funcs

### DIFF
--- a/src/main/c/EcfMultiple.c
+++ b/src/main/c/EcfMultiple.c
@@ -366,26 +366,14 @@ int GCI_triple_integral_fitting_engine_many(struct flim_params* flim) {
 int GCI_Phasor_many(struct flim_params* flim) {
 
 	float* temp_trans = allocate_temp_2d_row(flim->common->trans);
-	float* temp_fitted;
-	if(flim->common->residuals == NULL && flim->common->chisq == NULL){
-		temp_fitted = allocate_temp_2d_row(flim->common->fitted);
-	}
-	else{
-		temp_fitted = allocate_required_temp_2d_row(flim->common->fitted, flim->common->trans->sizes[1]);
-	}
+	float* temp_fitted = allocate_temp_2d_row(flim->common->fitted);
 	float* temp_residuals = allocate_temp_2d_row(flim->common->residuals);
 
 	for (int i = 0; i < flim->common->trans->sizes[0]; i++) {
 		if (flim->common->fit_mask == NULL || *array1d_int8_ptr(flim->common->fit_mask, i)) {
 
 			float* unstrided_trans = get_unstrided_2d_row_input(flim->common->trans, temp_trans, i);
-			float* unstrided_fitted;
-			if(flim->common->residuals == NULL && flim->common->chisq == NULL){
-				unstrided_fitted = get_unstrided_2d_row_output(flim->common->fitted, temp_fitted, i);
-			}
-			else{
-				unstrided_fitted = get_required_unstrided_2d_row_output(flim->common->fitted, temp_fitted, i);
-			}
+			float* unstrided_fitted = get_unstrided_2d_row_output(flim->common->fitted, temp_fitted, i);
 			float* unstrided_residuals = get_unstrided_2d_row_output(flim->common->residuals, temp_residuals, i);
 			float* unstrided_chisq = flim->common->chisq == NULL ? NULL : array1d_float_ptr(flim->common->chisq, i);
 

--- a/src/main/c/EcfSingle.c
+++ b/src/main/c/EcfSingle.c
@@ -387,8 +387,8 @@ int GCI_triple_integral_fitting_engine(float xincr, float y[], int fit_start, in
 	float local_chisq=3.0e38f, oldChisq=3.0e38f, oldZ, oldA, oldTau, *validFittedArray; // local_chisq a very high float but below oldChisq
 	int result = 0;
 
-	if (fitted==NULL)   // we require chisq but have not supplied a "fitted" array so must malloc one
-	{
+	// we require residuals or chisq but have not supplied a "fitted" array so must malloc one
+	if (fitted==NULL && (residuals!=NULL || chisq!=NULL)){
 		if ((validFittedArray = (float *)malloc((long unsigned int)fit_end * sizeof(float)))== NULL) return (-1);
 	}
 	else validFittedArray = fitted;

--- a/src/main/c/GCI_Phasor.c
+++ b/src/main/c/GCI_Phasor.c
@@ -91,7 +91,13 @@ int    GCI_Phasor(float xincr, float y[], int fit_start, int fit_end,
 	// fitted and residuals must be arrays big enough to hold possibly fit_end floats.
 
 	int   i, ret = PHASOR_ERR_NO_ERROR, nBins;
-	float *data, u, v, A, w, I, Ifit, bg, chisq_local, res, sigma2;
+	float *data, u, v, A, w, I, Ifit, bg, chisq_local, res, sigma2, *validFittedArray;
+
+	// we require residuals or chisq but have not supplied a "fitted" array so must malloc one
+	if (fitted==NULL && (residuals!=NULL || chisq!=NULL)){
+		if ((validFittedArray = (float *)malloc((long unsigned int)fit_end * sizeof(float)))== NULL) return (-1);
+	}
+	else validFittedArray = fitted;
 
 	data = &(y[fit_start]);	
 	nBins = (fit_end - fit_start);
@@ -129,10 +135,9 @@ int    GCI_Phasor(float xincr, float y[], int fit_start, int fit_end,
 	*V = v;
 
 	/* Now calculate the fitted curve and chi-squared if wanted. */
-	if (fitted == NULL)
+	if (validFittedArray == NULL)
 		return 0;
-
-	memset(fitted, 0, (size_t)fit_end * sizeof(float));
+	memset(validFittedArray, 0, (size_t)fit_end * sizeof(float));
 	if (residuals != NULL)
 		memset(residuals, 0, (size_t)fit_end * sizeof(float));
 	// Madison report some "memory issue", and replaced the 2 line above with new arrays.
@@ -146,7 +151,7 @@ int    GCI_Phasor(float xincr, float y[], int fit_start, int fit_end,
 
 	// Calculate fit
 	for (i=fit_start; i<fit_end; i++){
-		fitted[i] = bg + A * expf((float)(-(i-fit_start))*xincr/(*tau));
+		validFittedArray[i] = bg + A * expf((float)(-(i-fit_start))*xincr/(*tau));
 	}
 	// OK, so now fitted contains our data for the timeslice of interest.
 	// We can calculate a chisq value and plot the graph, along with
@@ -157,7 +162,7 @@ int    GCI_Phasor(float xincr, float y[], int fit_start, int fit_end,
 
 	chisq_local = 0.0f;
 	for (i=0; i<fit_start; i++) {
-		res = y[i]-fitted[i];
+		res = y[i]-validFittedArray[i];
 		if (residuals != NULL)
 			residuals[i] = res;
 	}
@@ -166,11 +171,11 @@ int    GCI_Phasor(float xincr, float y[], int fit_start, int fit_end,
 //	case NOISE_POISSON_FIT:
 		/* Summation loop over all data */
 		for (i=fit_start ; i<fit_end; i++) {
-			res = y[i] - fitted[i];
+			res = y[i] - validFittedArray[i];
 			if (residuals != NULL)
 				residuals[i] = res;
 			/* don't let variance drop below 1 */
-			sigma2 = (fitted[i] > 1 ? 1.0f/fitted[i] : 1.0f);
+			sigma2 = (validFittedArray[i] > 1 ? 1.0f/validFittedArray[i] : 1.0f);
 			chisq_local += res * res * sigma2;
 		}
 


### PR DESCRIPTION
I realized that fixing the optional computation of fitted, residuals and chisq should be put inside of the base (single pixel) functions rather than within the muli-pixel  functions I created for the python bindings. This fix makes sure that even if any one of these outputs are NULL, the other, non-NULL outputs are still computed.

I think that these changes are unlikely to affect anyone who depends on FLIMLib and if so, it should only affect runtime speed at worst.