### PR TITLE
fit range handles zero data case

### DIFF
--- a/src/main/c/EcfMultiple.c
+++ b/src/main/c/EcfMultiple.c
@@ -259,11 +259,17 @@ int GCI_marquardt_fitting_engine_many(struct flim_params* flim) {
 			float* unstrided_residuals = get_required_unstrided_2d_row_output(flim->common->residuals, temp_residuals, i);
 			float* unstrided_chisq = flim->common->chisq == NULL ? NULL : array1d_float_ptr(flim->common->chisq, i);
 
-			int error_code = GCI_marquardt_fitting_engine(flim->common->xincr, unstrided_trans, ndata, flim->common->fit_start, 
-				flim->common->fit_end, unstrided_instr, ninstr, flim->marquardt->noise, unstrided_sig, unstrided_param, 
-				temp_paramfree, nparam, flim->marquardt->restrain, flim->marquardt->fitfunc, unstrided_fitted, 
-				unstrided_residuals, unstrided_chisq, temp_covar, temp_alpha, temp_erraxes, flim->marquardt->chisq_target, 
-				flim->marquardt->chisq_delta, flim->marquardt->chisq_percent);
+			int error_code = 0;
+			if(flim->common->fit_start >= flim->common->fit_end || flim->common->xincr <= 0.0){
+				error_code = -1;
+			}
+			else{
+				error_code = GCI_marquardt_fitting_engine(flim->common->xincr, unstrided_trans, ndata, flim->common->fit_start, 
+					flim->common->fit_end, unstrided_instr, ninstr, flim->marquardt->noise, unstrided_sig, unstrided_param, 
+					temp_paramfree, nparam, flim->marquardt->restrain, flim->marquardt->fitfunc, unstrided_fitted, 
+					unstrided_residuals, unstrided_chisq, temp_covar, temp_alpha, temp_erraxes, flim->marquardt->chisq_target, 
+					flim->marquardt->chisq_delta, flim->marquardt->chisq_percent);
+			}
 			
 			if (error_code < 0){ // fit has failed
 				// fill all outputs with NaN
@@ -330,12 +336,17 @@ int GCI_triple_integral_fitting_engine_many(struct flim_params* flim) {
 			float* unstrided_fitted = get_unstrided_2d_row_output(flim->common->fitted, temp_fitted, i);
 			float* unstrided_residuals = get_unstrided_2d_row_output(flim->common->residuals, temp_residuals, i);
 			float* unstrided_chisq = flim->common->chisq == NULL ? NULL : array1d_float_ptr(flim->common->chisq, i);
-
-			int error_code = GCI_triple_integral_fitting_engine(flim->common->xincr, unstrided_trans, flim->common->fit_start, flim->common->fit_end,
-				unstrided_instr, ninstr, flim->triple_integral->noise, unstrided_sig,
-				array1d_float_ptr(flim->triple_integral->Z, i), array1d_float_ptr(flim->triple_integral->A, i),
-				array1d_float_ptr(flim->triple_integral->tau, i), unstrided_fitted, unstrided_residuals,
-				unstrided_chisq, chisq_target_in);
+			int error_code = 0;
+			if(flim->common->fit_start >= flim->common->fit_end || flim->common->xincr <= 0.0){
+				error_code = -1;
+			}
+			else{
+				error_code = GCI_triple_integral_fitting_engine(flim->common->xincr, unstrided_trans, flim->common->fit_start, flim->common->fit_end,
+					unstrided_instr, ninstr, flim->triple_integral->noise, unstrided_sig,
+					array1d_float_ptr(flim->triple_integral->Z, i), array1d_float_ptr(flim->triple_integral->A, i),
+					array1d_float_ptr(flim->triple_integral->tau, i), unstrided_fitted, unstrided_residuals,
+					unstrided_chisq, chisq_target_in);
+			}
 
 			if(error_code < 0){
 				*array1d_float_ptr(flim->triple_integral->Z, i) = NAN;
@@ -377,12 +388,18 @@ int GCI_Phasor_many(struct flim_params* flim) {
 			float* unstrided_residuals = get_unstrided_2d_row_output(flim->common->residuals, temp_residuals, i);
 			float* unstrided_chisq = flim->common->chisq == NULL ? NULL : array1d_float_ptr(flim->common->chisq, i);
 
-			int error_code = GCI_Phasor(flim->common->xincr, unstrided_trans, flim->common->fit_start, flim->common->fit_end,
-				array1d_float_ptr(flim->phasor->Z, i), array1d_float_ptr(flim->phasor->u, i), 
-				array1d_float_ptr(flim->phasor->v, i), array1d_float_ptr(flim->phasor->taup, i), 
-				array1d_float_ptr(flim->phasor->taum, i), array1d_float_ptr(flim->phasor->tau, i),
-				unstrided_fitted, unstrided_residuals, unstrided_chisq);
-			
+			int error_code = 0;
+			if(flim->common->fit_start >= flim->common->fit_end || flim->common->xincr <= 0.0){
+				error_code = -1;
+			}
+			else{
+				error_code = GCI_Phasor(flim->common->xincr, unstrided_trans, flim->common->fit_start, flim->common->fit_end,
+					array1d_float_ptr(flim->phasor->Z, i), array1d_float_ptr(flim->phasor->u, i), 
+					array1d_float_ptr(flim->phasor->v, i), array1d_float_ptr(flim->phasor->taup, i), 
+					array1d_float_ptr(flim->phasor->taum, i), array1d_float_ptr(flim->phasor->tau, i),
+					unstrided_fitted, unstrided_residuals, unstrided_chisq);
+			}
+
 			if (error_code < 0){
 				*array1d_float_ptr(flim->phasor->u, i) = NAN;
 				*array1d_float_ptr(flim->phasor->v, i) = NAN;

--- a/src/main/python/flimlib/cfunc.py
+++ b/src/main/python/flimlib/cfunc.py
@@ -451,13 +451,13 @@ def _prep_common_params(
         raise TypeError("photon_count must be array-like")
     fstart = 0 if fit_start is None else fit_start
     fend = dshape[-1] if fit_end is None else fit_end
-    assert 0 <= fstart < fend <= dshape[-1], "invalid fit range!"
+    assert 0 <= fstart <= fend <= dshape[-1], "invalid fit range!"
     common.fit_start = fstart
     common.fit_end = fend
     # triple_integral and phasor use fit_end as the size of the data
     data_shape = dshape if ndata_known else (*dshape[0:-1], fend)
     npixels = np.prod(data_shape[0:-1], dtype=int)
-
+    assert period > 0.0, "period must be greater than 0"
     common.xincr = period
     # the shape of trans is wildcard
     common.trans, referenced_trans = _as_strided_array(


### PR DESCRIPTION
The current implementation of the python bindings does not allow for empty data or similarly, `fit_start == fit_end`. It simply throws an error.

This PR addresses this by making sure that in this case, the outputs get properly `NaN` filled within the `EcfMultiple.c` functions. And therefore, the python side raises an error only if `fit_start > fit_end`.

Lastly, a check was added to ensure that `period` (the bin width) is greater than 0. This was done in both the C functions and the Python side. Perhaps this check should exist on only one or the other (if I were to choose, it would be python only).