### PR TITLE
Python releasing

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - "flimlib-[0-9]+.*"
 
 jobs:
   wheels:
@@ -36,3 +38,21 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           path: dist/*.tar.gz
+
+  pypi-upload:
+    if: >-
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/flimlib-')
+    needs:
+      - wheels
+      - sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@v1.5.0
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = flimlib
-version = 0.0.1.dev0
 author = Paul Barber, Curtis Rueden, Kevin Tan
 description = A python wrapper for flimlib's C functions
 long_description = file: README.md


### PR DESCRIPTION
Make releases happen automatically when a `flimlib-x.y.z` tag is created (using Maven).

- Read `pom.xml` to set version in `setup.py`
    - `*-SNAPSHOT` is converted to Python-style `*.dev0`
- Add GH Actions job to publish to PyPI

I have not yet added the PyPI API token. This needs to be done before the next release (see https://github.com/flimlib/flimlib/pull/67#issuecomment-1186563965).

Closes #68.