### PR TITLE
compute sine and cosine only once for many pixels

### DIFF
--- a/src/main/c/EcfMultiple.c
+++ b/src/main/c/EcfMultiple.c
@@ -216,9 +216,9 @@ int GCI_marquardt_fitting_engine_many(struct flim_params* flim) {
 	// ndata is the length of data to fit. will be sliced further using fit_start and fit_end
 	// fit_start and fit_end are not redundant with the stride characteristics of trans since
 	// on occasion data outside of the fit range is used for convolution with the "prompt" whatever that means
-	size_t ndata = flim->common->trans->sizes[1];
-	size_t nparam = flim->marquardt->param->sizes[1];
-	int ninstr = flim->marquardt->instr == NULL ? 0 : flim->marquardt->instr->sizes[0];
+	long ndata = (int)(flim->common->trans->sizes[1]);
+	long nparam = (long)(flim->marquardt->param->sizes[1]);
+	int ninstr = (int)(flim->marquardt->instr == NULL ? 0 : flim->marquardt->instr->sizes[0]);
 
 	// allocate inputs and outputs. they may be NULL (no memory used) if not needed
 	float* temp_trans = allocate_temp_2d_row(flim->common->trans);
@@ -315,7 +315,7 @@ int GCI_marquardt_fitting_engine_many(struct flim_params* flim) {
 }
 
 int GCI_triple_integral_fitting_engine_many(struct flim_params* flim) {
-	int ninstr = flim->marquardt->instr == NULL ? 0 : flim->marquardt->instr->sizes[0];
+	int ninstr = (int)(flim->marquardt->instr == NULL ? 0 : flim->marquardt->instr->sizes[0]);
 	// set the target to be INFINITY since this will cause the algorithm to iterate only once
 	float chisq_target_in = flim->triple_integral->chisq_target < 0 ? INFINITY : flim->triple_integral->chisq_target;
 	

--- a/src/main/c/EcfMultiple.c
+++ b/src/main/c/EcfMultiple.c
@@ -216,8 +216,8 @@ int GCI_marquardt_fitting_engine_many(struct flim_params* flim) {
 	// ndata is the length of data to fit. will be sliced further using fit_start and fit_end
 	// fit_start and fit_end are not redundant with the stride characteristics of trans since
 	// on occasion data outside of the fit range is used for convolution with the "prompt" whatever that means
-	long ndata = (int)(flim->common->trans->sizes[1]);
-	long nparam = (long)(flim->marquardt->param->sizes[1]);
+	int ndata = (int)(flim->common->trans->sizes[1]);
+	int nparam = (int)(flim->marquardt->param->sizes[1]);
 	int ninstr = (int)(flim->marquardt->instr == NULL ? 0 : flim->marquardt->instr->sizes[0]);
 
 	// allocate inputs and outputs. they may be NULL (no memory used) if not needed
@@ -377,15 +377,15 @@ int GCI_triple_integral_fitting_engine_many(struct flim_params* flim) {
 
 int GCI_Phasor_many(struct flim_params* flim) {
 
-	float *cos, *sin;
+	float *cosine, *sine;
 	int nBins = (flim->common->fit_end - flim->common->fit_start);
 	if (nBins > 0) {
-		cos = (float*)malloc((long unsigned int)nBins * sizeof(float));
-		sin = (float*)malloc((long unsigned int)nBins * sizeof(float));
-		createSinusoids(nBins, cos, sin);
+		cosine = malloc((size_t)nBins * sizeof(float));
+		sine = malloc((size_t)nBins * sizeof(float));
+		createSinusoids(nBins, cosine, sine);
 	}
 	else {
-		cos = sin = NULL;
+		cosine = sine = NULL;
 	}
 
 	float* temp_trans = allocate_temp_2d_row(flim->common->trans);
@@ -406,7 +406,7 @@ int GCI_Phasor_many(struct flim_params* flim) {
 			}
 			else{
 				error_code = GCI_Phasor_compute(flim->common->xincr, unstrided_trans, flim->common->fit_start, flim->common->fit_end,
-					array1d_float_ptr(flim->phasor->Z, i), cos, sin, array1d_float_ptr(flim->phasor->u, i), 
+					array1d_float_ptr(flim->phasor->Z, i), cosine, sine, array1d_float_ptr(flim->phasor->u, i), 
 					array1d_float_ptr(flim->phasor->v, i), array1d_float_ptr(flim->phasor->taup, i), 
 					array1d_float_ptr(flim->phasor->taum, i), array1d_float_ptr(flim->phasor->tau, i),
 					unstrided_fitted, unstrided_residuals, unstrided_chisq);
@@ -434,8 +434,8 @@ int GCI_Phasor_many(struct flim_params* flim) {
 	free(temp_fitted);
 	free(temp_residuals);
 
-	free(cos);
-	free(sin);
+	free(cosine);
+	free(sine);
 
 	return 0;
 }

--- a/src/main/c/EcfMultiple.h
+++ b/src/main/c/EcfMultiple.h
@@ -25,6 +25,9 @@
   * \file EcfMultiple.h
   */
 
+#ifndef _ECF_MULTIPLE_H
+#define _ECF_MULTIPLE_H
+
 #include "Ecf.h"
 
 #include <stddef.h>
@@ -347,3 +350,5 @@ int GCI_Phasor_many(struct flim_params* flim);
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+#endif /* _ECF_MULTIPLE_H */

--- a/src/main/c/GCI_Phasor.c
+++ b/src/main/c/GCI_Phasor.c
@@ -91,25 +91,26 @@ int GCI_Phasor(float xincr, float y[], int fit_start, int fit_end,
 	int nBins = (fit_end - fit_start);
 	if (nBins < 0)
 		return (PHASOR_ERR_INVALID_WINDOW);
-	float* cos = (float*)malloc((long unsigned int)nBins * sizeof(float));
-	float* sin = (float*)malloc((long unsigned int)nBins * sizeof(float));
-	createSinusoids(nBins, cos, sin);
-	int ret = GCI_Phasor_compute(xincr, y, fit_start, fit_end, Z, cos, sin, U, V, taup, taum, tau, fitted, residuals, chisq);
-	free(cos);
-	free(sin);
+	float* cosine = malloc((size_t)nBins * sizeof(float));
+	float* sine = malloc((size_t)nBins * sizeof(float));
+	createSinusoids(nBins, cosine, sine);
+	int ret = GCI_Phasor_compute(xincr, y, fit_start, fit_end, Z, cosine, sine, U, V, taup, taum, tau, fitted, residuals, chisq);
+	free(cosine);
+	free(sine);
 	return ret;
 }
 
-void createSinusoids(int nBins, float* cos, float* sin) {
+void createSinusoids(int nBins, float* cosine, float* sine) {
 	float w = 2.0f * 3.1415926535897932384626433832795028841971f / (float)nBins; //2.0*PI/(float)nBins;
+	// Take care that values correspond to the centre of the bin, hence i+0.5
 	for (int i = 0; i < nBins; i++) {
-		cos[i] = cosf(w * ((float)i + 0.5f));
-		sin[i] = sinf(w * ((float)i + 0.5f));
+		cosine[i] = cosf(w * ((float)i + 0.5f));
+		sine[i] = sinf(w * ((float)i + 0.5f));
 	}
 }
 
 int GCI_Phasor_compute(float xincr, float y[], int fit_start, int fit_end,
-	const float* Z, float* cos, float* sin, float* U, float* V, float* taup, float* taum, float* tau, float* fitted, float* residuals,
+	const float* Z, float* cosine, float* sine, float* U, float* V, float* taup, float* taum, float* tau, float* fitted, float* residuals,
 	float* chisq)
 {
     // Z must contain a bg estimate
@@ -141,10 +142,9 @@ int GCI_Phasor_compute(float xincr, float y[], int fit_start, int fit_end,
 		I += (data[i]-bg);
 
 	// Phasor coords
-	// Take care that values correspond to the centre of the bin, hence i+0.5
 	for (i = 0, u = 0.0f, v = 0.0f; i < nBins; i++) {
-		u += (data[i] - bg) * cos[i];
-		v += (data[i] - bg) * sin[i];
+		u += (data[i] - bg) * cosine[i];
+		v += (data[i] - bg) * sine[i];
 	}
 	u /= I;
 	v /= I;

--- a/src/main/c/GCI_PhasorInternal.h
+++ b/src/main/c/GCI_PhasorInternal.h
@@ -32,19 +32,20 @@ extern "C" {
 #endif
 
 /**
- * Generates one period of both a cosine and a sine
+ * Generates one period of both a cosine and a sine. Values are computed from
+ * the center of the bins.
  * 
  * \param[in] nBins The number of data points in the resulting sinusoids.
- * \param[out] cos The cosine result.
- * \param[out] sin The sine result.
+ * \param[out] cosine
+ * \param[out] sine
  */
-void createSinusoids(int nBins, float* cos, float* sin);
+void createSinusoids(int nBins, float* cosine, float* sine);
 
 /**
  * Handles the computation for phasor analysis utilizing a provided sine and cosine
  */
 int GCI_Phasor_compute(float xincr, float y[], int fit_start, int fit_end,
-	const float* Z, float* cos, float* sin, float* U, float* V, float* taup, 
+	const float* Z, float* cosine, float* sine, float* U, float* V, float* taup, 
 	float* taum, float* tau, float* fitted, float* residuals, float* chisq);
 
 #ifdef __cplusplus

--- a/src/main/c/GCI_PhasorInternal.h
+++ b/src/main/c/GCI_PhasorInternal.h
@@ -1,0 +1,54 @@
+/*
+ * #%L
+ * FLIMLib package for exponential curve fitting of fluorescence lifetime data.
+ * %%
+ * Copyright (C) 2010 - 2015 University of Oxford and Board of Regents of the
+ * University of Wisconsin-Madison.
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+ /* This is GCI_PhasorInternal.h, the header file for internal functions in
+	the 2022 version of the GCI_Phasor.c file. */
+
+#ifndef _PHASOR_FITTING_INTERNAL_H
+#define _PHASOR_FITTING_INTERNAL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Generates one period of both a cosine and a sine
+ * 
+ * \param[in] nBins The number of data points in the resulting sinusoids.
+ * \param[out] cos The cosine result.
+ * \param[out] sin The sine result.
+ */
+void createSinusoids(int nBins, float* cos, float* sin);
+
+/**
+ * Handles the computation for phasor analysis utilizing a provided sine and cosine
+ */
+int GCI_Phasor_compute(float xincr, float y[], int fit_start, int fit_end,
+	const float* Z, float* cos, float* sin, float* U, float* V, float* taup, 
+	float* taum, float* tau, float* fitted, float* residuals, float* chisq);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _PHASOR_FITTING_INTERNAL_H */


### PR DESCRIPTION
Improve the way that phasor is computed specifically for the `GCI_Phasor_many` function. cosine and sine are computed only once.

Running these from python I observed a reduction of runtime of about 30%.