### PR TITLE
Build wheels for each Python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,20 @@ target-version = ['py38']
 [tool.cibuildwheel]
 test-command = "python -m unittest discover -s {project}/src/test/python"
 build = [
-    # Only build with the minimum supported Python version, since we use the
-    # stable ABI (cp36-abi3, supporting 3.8 and later).
     "cp38-macosx_universal2",
     "cp38-win32",
     "cp38-win_amd64",
     "cp38-manylinux_x86_64",
+    "cp39-macosx_universal2",
+    "cp39-win32",
+    "cp39-win_amd64",
+    "cp39-manylinux_x86_64",
+    "cp310-macosx_universal2",
+    "cp310-win32",
+    "cp310-win_amd64",
+    "cp310-manylinux_x86_64",
+    "cp311-macosx_universal2",
+    "cp311-win32",
+    "cp311-win_amd64",
+    "cp311-manylinux_x86_64",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,3 @@ python_requires = >=3.8
 
 [options.packages.find]
 where = src/main/python
-
-[bdist_wheel]
-py_limited_api = cp36

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,6 @@ python_requires = >=3.8
 
 [options.packages.find]
 where = src/main/python
+
+[bdist_wheel]
+py_limited_api = cp36

--- a/setup.py
+++ b/setup.py
@@ -92,21 +92,11 @@ flimlib_ext = setuptools.Extension(
 )
 
 
-class bdist_wheel_abi3(bdist_wheel):
-    # See https://github.com/joerick/python-abi3-package-sample
-    def get_tag(self):
-        python, abi, plat = super().get_tag()
-        if python.startswith("cp"):
-            return "cp36", "abi3", plat
-        return python, abi, plat
-
-
 setuptools.setup(
     version=get_pep440_version(),
     install_requires=["numpy>=1.12.0"],
     ext_modules=[flimlib_ext],
     cmdclass={
         "build_ext": build_ext_c_cxx,
-        "bdist_wheel": bdist_wheel_abi3,
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,10 @@ flimlib_ext = setuptools.Extension(
     "flimlib._flimlib",
     sources=c_sources,
     extra_link_args=link_args,
+    py_limited_api=True,
+    define_macros=[
+        ("Py_LIMITED_API", "0x03060000"),
+    ],
 )
 
 
@@ -101,10 +105,6 @@ setuptools.setup(
     version=get_pep440_version(),
     install_requires=["numpy>=1.12.0"],
     ext_modules=[flimlib_ext],
-    py_limited_api=True,
-    define_macros=[
-        ("Py_LIMITED_API", "0x03060000"),
-    ],
     cmdclass={
         "build_ext": build_ext_c_cxx,
         "bdist_wheel": bdist_wheel_abi3,

--- a/setup.py
+++ b/setup.py
@@ -85,10 +85,6 @@ flimlib_ext = setuptools.Extension(
     "flimlib._flimlib",
     sources=c_sources,
     extra_link_args=link_args,
-    py_limited_api=True,
-    define_macros=[
-        ("Py_LIMITED_API", "0x03060000"),
-    ],
 )
 
 


### PR DESCRIPTION
Although inefficient, this is an easy solution to #73.
The 'correct' solution using the stable abi3 eludes me after much research (setuptools seems to ignore `Extension(py_limited_api=True)` in my hands).

Closes #73.