### PR TITLE
Enable Python 3.11 build

### DIFF
--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v3
-      - uses: pypa/cibuildwheel@v2.8.0
+      - uses: pypa/cibuildwheel@v2.11.2
         env:
           # On macOS/x86_64, default is x86_64 only
           CIBW_ARCHS_MACOS: x86_64 universal2 arm64

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         runner:
-          - ubuntu-20.04
-          - windows-2019
+          - ubuntu-22.04
+          - windows-2022
           - macos-12
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
Upgrade cibuildwheel to latest, which builds for Python 3.11.
Python 3.11 is already listed in pyproject.toml.
GitHub Actions hosted runner now has Python 3.11.

Also upgrade runner OS (Ubuntu, Windows), although not significant for Python 3.11.