### PR TITLE
Phasor IRF Deconvolution

### DIFF
--- a/src/main/c/EcfMultiple.c
+++ b/src/main/c/EcfMultiple.c
@@ -218,18 +218,18 @@ int GCI_marquardt_fitting_engine_many(struct flim_params* flim) {
 	// on occasion data outside of the fit range is used for convolution with the "prompt" whatever that means
 	int ndata = (int)(flim->common->trans->sizes[1]);
 	int nparam = (int)(flim->marquardt->param->sizes[1]);
-	int ninstr = (int)(flim->marquardt->instr == NULL ? 0 : flim->marquardt->instr->sizes[0]);
+	int ninstr = (int)(flim->common->instr == NULL ? 0 : flim->common->instr->sizes[0]);
 
 	// allocate inputs and outputs. they may be NULL (no memory used) if not needed
 	float* temp_trans = allocate_temp_2d_row(flim->common->trans);
-	float* temp_instr = allocate_temp_1d(flim->marquardt->instr);
+	float* temp_instr = allocate_temp_1d(flim->common->instr);
 	float* temp_sig = allocate_temp_1d(flim->marquardt->sig);
 	float* temp_param = allocate_temp_2d_row(flim->marquardt->param);
 	float* temp_fitted = allocate_required_temp_2d_row(flim->common->fitted, ndata);
 	float* temp_residuals = allocate_required_temp_2d_row(flim->common->residuals, ndata);
 
 	// these two don't get modified by the algorithm and are constant for all pixels
-	float* unstrided_instr = get_unstrided_1d_input(flim->marquardt->instr, temp_instr);
+	float* unstrided_instr = get_unstrided_1d_input(flim->common->instr, temp_instr);
 	float* unstrided_sig = get_unstrided_1d_input(flim->marquardt->sig, temp_sig);
 
 	// paramfree passed to marquardt must not be NULL! if NULL we want to leave all parameters free
@@ -315,19 +315,19 @@ int GCI_marquardt_fitting_engine_many(struct flim_params* flim) {
 }
 
 int GCI_triple_integral_fitting_engine_many(struct flim_params* flim) {
-	int ninstr = (int)(flim->marquardt->instr == NULL ? 0 : flim->marquardt->instr->sizes[0]);
+	int ninstr = (int)(flim->common->instr == NULL ? 0 : flim->common->instr->sizes[0]);
 	// set the target to be INFINITY since this will cause the algorithm to iterate only once
 	float chisq_target_in = flim->triple_integral->chisq_target < 0 ? INFINITY : flim->triple_integral->chisq_target;
 	
 	// allocate inputs and outputs. they may be NULL (no memory used) if not needed
 	float* temp_trans = allocate_temp_2d_row(flim->common->trans);
-	float* temp_instr = allocate_temp_1d(flim->triple_integral->instr);
+	float* temp_instr = allocate_temp_1d(flim->common->instr);
 	float* temp_sig = allocate_temp_1d(flim->triple_integral->sig);
 	float* temp_fitted = allocate_temp_2d_row(flim->common->fitted);
 	float* temp_residuals = allocate_temp_2d_row(flim->common->residuals);
 	
 	// these two don't get modified by the algorithm and are constant for all pixels
-	float* unstrided_instr = get_unstrided_1d_input(flim->triple_integral->instr, temp_instr);
+	float* unstrided_instr = get_unstrided_1d_input(flim->common->instr, temp_instr);
 	float* unstrided_sig = get_unstrided_1d_input(flim->triple_integral->sig, temp_sig);
 
 	for (int i = 0; i < flim->common->trans->sizes[0]; i++) {
@@ -377,20 +377,32 @@ int GCI_triple_integral_fitting_engine_many(struct flim_params* flim) {
 
 int GCI_Phasor_many(struct flim_params* flim) {
 
-	float *cosine, *sine;
+	float uinstr, vinstr;
+	float *cosine, *sine, *Uinstr = &uinstr, *Vinstr = &vinstr;
 	int nBins = (flim->common->fit_end - flim->common->fit_start);
+	int ninstr = (int)(flim->common->instr == NULL ? 0 : flim->common->instr->sizes[0]);
+
+	// allocate inputs and outputs. they may be NULL (no memory used) if not needed
+	float* temp_instr = allocate_temp_1d(flim->common->instr);
+	float* temp_trans = allocate_temp_2d_row(flim->common->trans);
+	float* temp_fitted = allocate_temp_2d_row(flim->common->fitted);
+	float* temp_residuals = allocate_temp_2d_row(flim->common->residuals);
+
 	if (nBins > 0) {
 		cosine = malloc((size_t)nBins * sizeof(float));
 		sine = malloc((size_t)nBins * sizeof(float));
 		createSinusoids(nBins, cosine, sine);
+		if (ninstr > 0){
+			float* unstrided_instr = get_unstrided_1d_input(flim->common->instr, temp_instr);
+			computeInstrPhasor(flim->common->xincr, unstrided_instr, min(ninstr, nBins), cosine, sine, Uinstr, Vinstr);
+		}
+		else{
+			Uinstr = Vinstr = NULL;
+		}
 	}
 	else {
 		cosine = sine = NULL;
 	}
-
-	float* temp_trans = allocate_temp_2d_row(flim->common->trans);
-	float* temp_fitted = allocate_temp_2d_row(flim->common->fitted);
-	float* temp_residuals = allocate_temp_2d_row(flim->common->residuals);
 
 	for (int i = 0; i < flim->common->trans->sizes[0]; i++) {
 		if (flim->common->fit_mask == NULL || *array1d_int8_ptr(flim->common->fit_mask, i)) {
@@ -405,8 +417,8 @@ int GCI_Phasor_many(struct flim_params* flim) {
 				error_code = -1;
 			}
 			else{
-				error_code = GCI_Phasor_compute(flim->common->xincr, unstrided_trans, flim->common->fit_start, flim->common->fit_end,
-					array1d_float_ptr(flim->phasor->Z, i), cosine, sine, array1d_float_ptr(flim->phasor->u, i), 
+				error_code = GCI_Phasor_compute_instr(flim->common->xincr, unstrided_trans, flim->common->fit_start, flim->common->fit_end,
+					array1d_float_ptr(flim->phasor->Z, i), cosine, sine, Uinstr, Vinstr, array1d_float_ptr(flim->phasor->u, i), 
 					array1d_float_ptr(flim->phasor->v, i), array1d_float_ptr(flim->phasor->taup, i), 
 					array1d_float_ptr(flim->phasor->taum, i), array1d_float_ptr(flim->phasor->tau, i),
 					unstrided_fitted, unstrided_residuals, unstrided_chisq);
@@ -430,6 +442,7 @@ int GCI_Phasor_many(struct flim_params* flim) {
 			}
 		}
 	}
+	free(temp_instr);
 	free(temp_trans);
 	free(temp_fitted);
 	free(temp_residuals);

--- a/src/main/c/EcfMultiple.h
+++ b/src/main/c/EcfMultiple.h
@@ -90,6 +90,12 @@ struct common_params {
 	int fit_end; 
 
 	/**
+	 * [in] instr The instrument reponse(IRF) or prompt signal to be used
+	 * (optional, can pass NULL).
+	 */
+	struct array1d* instr;
+
+	/**
 	 * [out] Fitted values coincident in time with data points 
 	 * (optional, can pass NULL).
 	 */
@@ -116,12 +122,6 @@ struct common_params {
 
 /** A structure containing parameters used in LMA */
 struct marquardt_params {
-	/**
-	 * [in] instr The instrument reponse(IRF) or prompt signal to be used
-	 * (optional, can pass NULL).
-	 */
-	struct array1d* instr;
-
 	/**
 	 * [in] The noise_type to be used
 	 */
@@ -231,12 +231,6 @@ struct phasor_params {
 
 /** A structure containing parameters used in RLD */
 struct triple_integral_params {
-	/**
-	 * [in] instr The instrument reponse(IRF) or prompt signal to be used 
-	 * (optional, can pass NULL).
-	 */
-	struct array1d* instr; 
-
 	/**
 	 * [in] The noise_type to be used
 	 */

--- a/src/main/c/EcfSingle.c
+++ b/src/main/c/EcfSingle.c
@@ -1928,6 +1928,9 @@ int GCI_marquardt_fitting_engine(float xincr, float *trans, int ndata, int fit_s
 	if (tries >= MAXREFITS && local_chisq > chisq_target) // maxrefits reached and target not reached
 		return -6;
 
+	if (local_chisq > chisq_target)
+    	return -7;
+
 	return error == 0 ? total_iters : error;
 }
 

--- a/src/main/c/GCI_PhasorInternal.h
+++ b/src/main/c/GCI_PhasorInternal.h
@@ -42,10 +42,25 @@ extern "C" {
 void createSinusoids(int nBins, float* cosine, float* sine);
 
 /**
+ * Computes the scaled phasor for the instrument response function
+ */
+void computeInstrPhasor(float xincr, float instr[], int ninstr,
+	float* cosine, float* sine, float* Uinstr, float* Vinstr);
+
+/**
  * Handles the computation for phasor analysis utilizing a provided sine and cosine
  */
 int GCI_Phasor_compute(float xincr, float y[], int fit_start, int fit_end,
 	const float* Z, float* cosine, float* sine, float* U, float* V, float* taup, 
+	float* taum, float* tau, float* fitted, float* residuals, float* chisq);
+
+/**
+ * Handles the computation for phasor analysis utilizing a provided sine and cosine
+ * Uinstr and Vinstr must be provided by `computeInstr`
+ * If Uinstr and Vinstr are not NULL, a deconvolution of the IRF is performed
+ */
+int GCI_Phasor_compute_instr(float xincr, float y[], int fit_start, int fit_end,
+	const float* Z, float* cosine, float* sine, float* Uinstr, float* Vinstr, float* U, float* V, float* taup, 
 	float* taum, float* tau, float* fitted, float* residuals, float* chisq);
 
 #ifdef __cplusplus

--- a/src/main/python/flimlib/cfunc.py
+++ b/src/main/python/flimlib/cfunc.py
@@ -709,6 +709,17 @@ def GCI_marquardt_fitting_engine(
         that fails, its corresponding outputs are filled with `NaN`
     """
 
+    # this edge case must be avoided because of a bug with flimlib
+    # it would result in the result being shifted by `fit_start`
+    if not (
+        fitfunc is GCI_multiexp_tau or
+        fitfunc is GCI_multiexp_lambda or
+        fitfunc is GCI_stretchedexp or
+        fit_start is None or 
+        fit_start == 0
+    ):
+        raise ValueError("If using a custom fitfunc, `fit_start` must be None or 0")
+
     (
         common_in,
         fitted_out,

--- a/src/main/python/flimlib/cfunc.py
+++ b/src/main/python/flimlib/cfunc.py
@@ -622,7 +622,7 @@ def GCI_marquardt_fitting_engine(
         `fitfunc`
     fit_start : {None, int}, optional
         The index of the start of the fit. Some data before this start index is
-        required if convolving with the prompt. If is None, the fit will begin
+        required if convolving with `instr`. If is None, the fit will begin
         at index 0 (default is None)
     fit_end : {None, int}, optional
         The index of the end of the fit. If is None, the fit will cover the
@@ -931,13 +931,14 @@ def GCI_triple_integral_fitting_engine(
         preserved in the outputs.
     fit_start : {None, int}, optional
         The index of the start of the fit. Some data before this start index is
-        required if convolving with the prompt.
+        required if convolving with `instr`.
         If is None, the fit will begin at index 0 (default is None)
     fit_end : {None, int}, optional
         The index of the end of the fit. If is None, the fit will cover the
         entire time axis of `photon_count`
     instr : {None, array_like}, optional
         A 1D array containing the instrument response (IRF) or prompt signal.
+        May improve estimate of `A`.
         If is None, no instrument response will be used (default is None)
     noise_type : str, optional
         The noise type to use. Valid values are: 'NOISE_CONST', 'NOISE_GIVEN',
@@ -1146,13 +1147,14 @@ def GCI_Phasor(
         preserved in the outputs.
     fit_start : {None, int}, optional
         The index of the start of the fit. Some data before this start index is
-        required if convolving with the prompt.
+        required if convolving with `instr`.
         If is None, the fit will begin at index 0 (default is None)
     fit_end : {None, int}, optional
         The index of the end of the fit. If is None, the fit will cover the
         entire time axis of `photon_count`
     instr : {None, array_like}, optional
         A 1D array containing the instrument response (IRF) or prompt signal.
+        May improve accuracy of the phasor coordinates `u` and `v`.
         If is None, no instrument response will be used (default is None)
     Z : {float, array_like}, optional
         The background to be subtracted from the data. If is a float, it will

--- a/src/test-many/c/test-many.c
+++ b/src/test-many/c/test-many.c
@@ -80,9 +80,9 @@ int main() {
 	float *chisq_data[NROWS];
 	struct array1d chisq = {chisq_data, NROWS, sizeof(float)};
 
-	struct common_params common_in = {.xincr=period, .trans=&photonCount2d, .fit_start=0, .fit_end=NDATA, .fitted=&fitted2d, .residuals=&residuals2d, .chisq=&chisq, .fit_mask=NULL};
+	struct common_params common_in = {.xincr=period, .trans=&photonCount2d, .fit_start=0, .fit_end=NDATA, .instr=NULL, .fitted=&fitted2d, .residuals=&residuals2d, .chisq=&chisq, .fit_mask=NULL};
 
-	struct marquardt_params marquardt_in = {.instr=NULL, .noise=NOISE_POISSON_FIT, .sig=NULL, .param=&param2d, .paramfree=NULL, 
+	struct marquardt_params marquardt_in = {.noise=NOISE_POISSON_FIT, .sig=NULL, .param=&param2d, .paramfree=NULL, 
 		.restrain=ECF_RESTRAIN_DEFAULT, .fitfunc=GCI_multiexp_tau, .covar=&covar, .alpha=&alpha, .erraxes=&erraxes, .chisq_target=1.1, .chisq_delta=1E-5, .chisq_percent=95 };
 
 	struct flim_params flim_in = { &common_in, &marquardt_in };

--- a/src/test/python/test_flimlib.py
+++ b/src/test/python/test_flimlib.py
@@ -764,14 +764,23 @@ class TestMarquardt(unittest.TestCase):
         self.assertAlmostEqual((result.param[1] - a_in) / a_in, 0, PRECISION)
         self.assertAlmostEqual((result.param[2] - tau_in) / tau_in, 0, PRECISION)
 
+    def test_output_margin_single_fit_bad_init(self):
+        # MAJOR offset to initial parameters
+        param_in = np.asarray([-1, a_in / 2, tau_in + 1], dtype=np.float32)
+        result = flimlib.GCI_marquardt_fitting_engine(
+            period, photon_count32, param_in,
+        )
+        self.assertTrue(np.all(np.isnan(result.param)))
+
     def test_paramfree_single_fit(self):
         # slight offset to detect if the fitting works!
-        param_in = np.asarray([0, a_in + 1, tau_in + 1], dtype=np.float32)
+        offset = 0.000042
+        param_in = np.asarray([0, a_in + offset, tau_in + 1], dtype=np.float32)
         result = flimlib.GCI_marquardt_fitting_engine(
             period, photon_count32, param_in, paramfree=[1, 0, 1]
         )
         # second parameter should have been held fixed!
-        self.assertAlmostEqual((a_in + 1 - result.param[1]) / (a_in + 1), 0, PRECISION)
+        self.assertEqual(result.param[1], np.float32(a_in + offset))
 
     def test_restraintype_single_fit(self):
         with self.assertRaises(ValueError):
@@ -1101,13 +1110,14 @@ class TestMarquardt(unittest.TestCase):
         self.assertTrue(np.all(np.isnan(result.fitted[1])))
 
     def test_paramfree(self):
+        offset = 0.000042
         param_in = np.asarray(
-            [[0, a_in + 1, tau_in + 1] for i in range(pixels)], dtype=np.float32
+            [[0, a_in + offset, tau_in + 1] for i in range(pixels)], dtype=np.float32
         )
         result = flimlib.GCI_marquardt_fitting_engine(
             period, photon_count2d, param_in, paramfree=[1, 0, 1]
         )
-        self.assertEqual(result.param[0][1], a_in + 1)
+        self.assertTrue(np.all(result.param[:,1] == np.float32(a_in + offset)))
 
     def test_size_zero_input(self):
         result = flimlib.GCI_marquardt_fitting_engine(period, [[]], [[]])

--- a/src/test/python/test_flimlib.py
+++ b/src/test/python/test_flimlib.py
@@ -837,6 +837,20 @@ class TestMarquardt(unittest.TestCase):
         self.assertAlmostEqual(0.0, result.param[0], PRECISION)
         self.assertAlmostEqual((linear_const - result.param[1]) / linear_const, 0, PRECISION)
 
+    def test_fitfunc_fit_start(self):
+        # slight offset to detect if the fitting works!
+        param_in = np.asarray([0, a_in + 1, tau_in + 1], dtype=np.float32)
+        fitfunc_in = flimlib.FitFunc(
+            dummy_exp_tau, nparam_predicate=dummy_exp_tau_predicate
+        )
+        with self.assertRaises(ValueError):
+            result = flimlib.GCI_marquardt_fitting_engine(
+                period, photon_count32, param_in, fitfunc=fitfunc_in, fit_start=samples//4
+            )
+        #self.assertAlmostEqual(0.0, result.param[0], PRECISION)
+        #self.assertAlmostEqual((result.param[1] - a_in) / a_in, 0, PRECISION)
+        #self.assertAlmostEqual((result.param[2] - tau_in) / tau_in, 0, PRECISION)
+
     def test_nparam(self):
         with self.assertRaises(TypeError):
             # forgot the first parameter!

--- a/src/test/python/test_flimlib.py
+++ b/src/test/python/test_flimlib.py
@@ -1184,6 +1184,16 @@ class TestMarquardt(unittest.TestCase):
         )
         flimlib.GCI_marquardt_fitting_engine(period, photon_count32, param_in)
 
+    def test_noise_mle_single_fit(self):
+        # slight offset to detect if the fitting works!
+        param_in = np.asarray([0, a_in + 1, tau_in + 1], dtype=np.float32)
+        result = flimlib.GCI_marquardt_fitting_engine(
+            period, photon_count32, param_in, noise_type="NOISE_MLE", paramfree=[0, 1, 1],
+        )
+        # the precision of MLE seems lower for this ideal data
+        self.assertAlmostEqual(result.param[0], 0, PRECISION - 2)
+        self.assertAlmostEqual((result.param[1] - a_in) / a_in, 0, PRECISION - 2)
+        self.assertAlmostEqual((result.param[2] - tau_in) / tau_in, 0, PRECISION - 2)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Using the method described in [Martelo et al. 2015](https://doi.org/10.1021/acs.jpcb.5b00261), I have added a way to provide the instrument response function (IRF) to Phasor analysis in flimlib.

In my tests, this was not able to improve lifetime estimations with typical IRFs, but the phasor coordinates were more accurate.